### PR TITLE
Use the verbatim Apache license text and name the copyright holder

### DIFF
--- a/LICENSE
+++ b/LICENSE
@@ -1,3 +1,4 @@
+
                                  Apache License
                            Version 2.0, January 2004
                         http://www.apache.org/licenses/
@@ -178,7 +179,7 @@
    APPENDIX: How to apply the Apache License to your work.
 
       To apply the Apache License to your work, attach the following
-      boilerplate notice, with the fields enclosed by brackets "{}"
+      boilerplate notice, with the fields enclosed by brackets "[]"
       replaced with your own identifying information. (Don't include
       the brackets!)  The text should be enclosed in the appropriate
       comment syntax for the file format. We also recommend that a
@@ -186,7 +187,7 @@
       same "printed page" as the copyright notice for easier
       identification within third-party archives.
 
-   Copyright 2016 The Thingsboard Authors
+   Copyright [yyyy] [name of copyright owner]
 
    Licensed under the Apache License, Version 2.0 (the "License");
    you may not use this file except in compliance with the License.

--- a/NOTICE
+++ b/NOTICE
@@ -1,5 +1,5 @@
 ngx-flowchart
-Copyright 2016 The Thingsboard Authors
+Copyright 2016 ThingsBoard, Inc.
 
 This product includes software developed at ONE LOGIC.
 

--- a/README.md
+++ b/README.md
@@ -64,7 +64,7 @@ new `release/x.y.z` branch. The version in
 
 ## License
 
-Copyright 2016 The Thingsboard Authors. Licensed under the
+Copyright 2016 ThingsBoard, Inc. Licensed under the
 [Apache License, Version 2.0](LICENSE).
 
 This library is an Angular port of [ngFlowchart](https://github.com/DaHaiz/ngFlowchart),

--- a/dist/ngx-flowchart/LICENSE
+++ b/dist/ngx-flowchart/LICENSE
@@ -1,3 +1,4 @@
+
                                  Apache License
                            Version 2.0, January 2004
                         http://www.apache.org/licenses/
@@ -178,7 +179,7 @@
    APPENDIX: How to apply the Apache License to your work.
 
       To apply the Apache License to your work, attach the following
-      boilerplate notice, with the fields enclosed by brackets "{}"
+      boilerplate notice, with the fields enclosed by brackets "[]"
       replaced with your own identifying information. (Don't include
       the brackets!)  The text should be enclosed in the appropriate
       comment syntax for the file format. We also recommend that a
@@ -186,7 +187,7 @@
       same "printed page" as the copyright notice for easier
       identification within third-party archives.
 
-   Copyright 2016 The Thingsboard Authors
+   Copyright [yyyy] [name of copyright owner]
 
    Licensed under the Apache License, Version 2.0 (the "License");
    you may not use this file except in compliance with the License.

--- a/dist/ngx-flowchart/NOTICE
+++ b/dist/ngx-flowchart/NOTICE
@@ -1,5 +1,5 @@
 ngx-flowchart
-Copyright 2016 The Thingsboard Authors
+Copyright 2016 ThingsBoard, Inc.
 
 This product includes software developed at ONE LOGIC.
 

--- a/dist/ngx-flowchart/README.md
+++ b/dist/ngx-flowchart/README.md
@@ -414,7 +414,7 @@ alongside canvas-wide methods such as `isEditable()`, `selectAll()`,
 
 ## License
 
-Copyright 2016 The Thingsboard Authors. Licensed under the
+Copyright 2016 ThingsBoard, Inc. Licensed under the
 [Apache License, Version 2.0](LICENSE).
 
 This library is an Angular port of [ngFlowchart](https://github.com/DaHaiz/ngFlowchart),

--- a/projects/ngx-flowchart/LICENSE
+++ b/projects/ngx-flowchart/LICENSE
@@ -1,3 +1,4 @@
+
                                  Apache License
                            Version 2.0, January 2004
                         http://www.apache.org/licenses/
@@ -178,7 +179,7 @@
    APPENDIX: How to apply the Apache License to your work.
 
       To apply the Apache License to your work, attach the following
-      boilerplate notice, with the fields enclosed by brackets "{}"
+      boilerplate notice, with the fields enclosed by brackets "[]"
       replaced with your own identifying information. (Don't include
       the brackets!)  The text should be enclosed in the appropriate
       comment syntax for the file format. We also recommend that a
@@ -186,7 +187,7 @@
       same "printed page" as the copyright notice for easier
       identification within third-party archives.
 
-   Copyright 2016 The Thingsboard Authors
+   Copyright [yyyy] [name of copyright owner]
 
    Licensed under the Apache License, Version 2.0 (the "License");
    you may not use this file except in compliance with the License.

--- a/projects/ngx-flowchart/NOTICE
+++ b/projects/ngx-flowchart/NOTICE
@@ -1,5 +1,5 @@
 ngx-flowchart
-Copyright 2016 The Thingsboard Authors
+Copyright 2016 ThingsBoard, Inc.
 
 This product includes software developed at ONE LOGIC.
 

--- a/projects/ngx-flowchart/README.md
+++ b/projects/ngx-flowchart/README.md
@@ -414,7 +414,7 @@ alongside canvas-wide methods such as `isEditable()`, `selectAll()`,
 
 ## License
 
-Copyright 2016 The Thingsboard Authors. Licensed under the
+Copyright 2016 ThingsBoard, Inc. Licensed under the
 [Apache License, Version 2.0](LICENSE).
 
 This library is an Angular port of [ngFlowchart](https://github.com/DaHaiz/ngFlowchart),


### PR DESCRIPTION
LICENSE had two edits against the canonical Apache-2.0 text: the appendix said brackets "{}" instead of "[]", and its placeholder was replaced with the copyright line. The file now matches https://www.apache.org/licenses/LICENSE-2.0.txt byte for byte, which is also what kubernetes/kubernetes and apache/kafka ship.

The appendix is guidance for applying the license to source files rather than part of the terms, and the Apache Software Foundation expects LICENSE to be verbatim with the copyright recorded in NOTICE. NOTICE did not exist until recently, which is why the copyright lived in the appendix; it now carries the copyright on its own.

The copyright holder is named ThingsBoard, Inc. rather than The Thingsboard Authors, in NOTICE and in both README files.