### PR TITLE
docs: attribute the scrollparent.js origin

### DIFF
--- a/LICENSE
+++ b/LICENSE
@@ -216,3 +216,9 @@ This library is an Angular port of ngFlowchart
 licensed under the MIT License. The original work has been modified and
 extended.
 See `/licenses/LICENSE-ngFlowchart` for details of the license.
+
+MIT (scrollparent.js):
+The scrollparent.ts source file is a TypeScript adaptation of
+scrollparent.js (https://github.com/olahol/scrollparent.js),
+Copyright (c) 2014 Ola Holmström, licensed under the MIT License.
+See `/licenses/LICENSE-scrollparent` for details of the license.

--- a/NOTICE
+++ b/NOTICE
@@ -19,3 +19,11 @@ functionality.
 
 ngFlowchart is distributed under the MIT License. The full licence text is
 in licenses/LICENSE-ngFlowchart.
+
+The scrollparent.ts source file is a TypeScript adaptation of
+scrollparent.js by Ola Holmström:
+
+    https://github.com/olahol/scrollparent.js
+
+scrollparent.js is distributed under the MIT License. The full licence text
+is in licenses/LICENSE-scrollparent.

--- a/licenses/LICENSE-scrollparent
+++ b/licenses/LICENSE-scrollparent
@@ -1,0 +1,21 @@
+The MIT License
+
+Copyright (c) 2014 Ola Holmström <olaholmstrom+github@gmail.com>
+
+Permission is hereby granted, free of charge, to any person obtaining a copy of
+this software and associated documentation files (the "Software"), to deal in
+the Software without restriction, including without limitation the rights to
+use, copy, modify, merge, publish, distribute, sublicense, and/or sell copies
+of the Software, and to permit persons to whom the Software is furnished to do
+so, subject to the following conditions:
+
+The above copyright notice and this permission notice shall be included in all
+copies or substantial portions of the Software.
+
+THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+SOFTWARE.

--- a/projects/ngx-flowchart/src/lib/scrollparent.ts
+++ b/projects/ngx-flowchart/src/lib/scrollparent.ts
@@ -2,6 +2,12 @@
 /// SPDX-FileCopyrightText: Copyright 2016 ThingsBoard, Inc.
 /// SPDX-License-Identifier: Apache-2.0
 ///
+///
+/// This file is a TypeScript adaptation of scrollparent.js
+/// (https://github.com/olahol/scrollparent.js),
+/// Copyright (c) 2014 Ola Holmström, licensed under the MIT License.
+/// See licenses/LICENSE-scrollparent for the original licence text.
+///
 const regex = /(auto|scroll)/;
 
 const style = (node: Element, prop: string): string =>


### PR DESCRIPTION
Follow-up to #73, resolving the one provenance question it left open.

`scrollparent.ts` is a TypeScript adaptation of [scrollparent.js](https://github.com/olahol/scrollparent.js) by Ola Holmström, MIT-licensed. The evidence: the file has been byte-identical since it arrived in the 2019 initial implementation, and three building blocks are verbatim from the 2014 original — the `style` helper (`getComputedStyle(node, null).getPropertyValue(prop)`), the `overflow + overflow-y + overflow-x` concatenation in the same order, and the `/(auto|scroll)/` regex — with matching function names (`style`, `scroll`, `scrollparent`). #73 gave the file a plain first-party header, which under-attributes it.

The MIT licence requires its copyright and permission notice to accompany copies and substantial portions of the software, so this PR gives the file the same treatment ngFlowchart already has:

- a derivation note under the header in `scrollparent.ts`, naming the origin, copyright holder and licence;
- the original MIT text as `licenses/LICENSE-scrollparent` — the `licenses/` directory already ships in the artifact as an ng-package asset, so no packaging change is needed;
- matching entries in the `LICENSE` subcomponents section and in `NOTICE`.

`node scripts/license.mjs check` passes (the enforced header stays first). The file now scans as `Apache-2.0 AND MIT` with both copyright statements parsed — which is the true licensing of an MIT-derived file offered under Apache-2.0.

After merging, `dist/` and the release branch will trail master again the same way they did after #73 — the rebuild + refresh dance from `8f6f4de`/`6f77d66` applies once more.
